### PR TITLE
Add option to select Bor instance

### DIFF
--- a/dashboards/bor.json
+++ b/dashboards/bor.json
@@ -77,21 +77,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "system_cpu_sysload",
+          "expr": "system_cpu_sysload{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "system",
           "refId": "A"
         },
         {
-          "expr": "system_cpu_syswait",
+          "expr": "system_cpu_syswait{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "iowait",
           "refId": "B"
         },
         {
-          "expr": "system_cpu_procload",
+          "expr": "system_cpu_procload{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "geth",
@@ -183,21 +183,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(system_memory_allocs[1m])",
+          "expr": "rate(system_memory_allocs{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "alloc",
           "refId": "A"
         },
         {
-          "expr": "system_memory_used",
+          "expr": "system_memory_used{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "used",
           "refId": "B"
         },
         {
-          "expr": "system_memory_held",
+          "expr": "system_memory_held{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "held",
@@ -289,14 +289,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(system_disk_readbytes[1m])",
+          "expr": "rate(system_disk_readbytes{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "read",
           "refId": "A"
         },
         {
-          "expr": "rate(system_disk_writebytes[1m])",
+          "expr": "rate(system_disk_writebytes{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "write",
@@ -402,14 +402,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(p2p_ingress[1m])",
+          "expr": "rate(p2p_ingress{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "ingress",
           "refId": "B"
         },
         {
-          "expr": "rate(p2p_egress[1m])",
+          "expr": "rate(p2p_egress{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "egress",
@@ -501,21 +501,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "p2p_peers",
+          "expr": "p2p_peers{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "peers",
           "refId": "A"
         },
         {
-          "expr": "rate(p2p_dials[1m])",
+          "expr": "rate(p2p_dials{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "dials",
           "refId": "B"
         },
         {
-          "expr": "rate(p2p_serves[1m])",
+          "expr": "rate(p2p_serves{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "serves",
@@ -638,7 +638,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "chain_head_header",
+          "expr": "chain_head_header{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -702,21 +702,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "chain_head_header",
+          "expr": "chain_head_header{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "header",
           "refId": "A"
         },
         {
-          "expr": "chain_head_receipt",
+          "expr": "chain_head_receipt{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "receipt",
           "refId": "B"
         },
         {
-          "expr": "chain_head_block",
+          "expr": "chain_head_block{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "block",
@@ -825,7 +825,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "txpool_pending",
+          "expr": "txpool_pending{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -889,21 +889,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "txpool_pending",
+          "expr": "txpool_pending{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "executable",
           "refId": "A"
         },
         {
-          "expr": "txpool_queued",
+          "expr": "txpool_queued{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "gapped",
           "refId": "B"
         },
         {
-          "expr": "txpool_local",
+          "expr": "txpool_local{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "local",
@@ -1012,7 +1012,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "chain_head_receipt",
+          "expr": "chain_head_receipt{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1094,7 +1094,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "txpool_queued",
+          "expr": "txpool_queued{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1176,7 +1176,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "chain_head_block",
+          "expr": "chain_head_block{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1258,7 +1258,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "txpool_local",
+          "expr": "txpool_local{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1324,14 +1324,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "chain_execution{quantile=\"$quantile\"}",
+          "expr": "chain_execution{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "execution (q=$quantile)",
           "refId": "A"
         },
         {
-          "expr": "chain_validation{quantile=\"$quantile\"}",
+          "expr": "chain_validation{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1340,7 +1340,7 @@
           "refId": "B"
         },
         {
-          "expr": "chain_write{quantile=\"$quantile\"}",
+          "expr": "chain_write{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1348,56 +1348,56 @@
           "refId": "C"
         },
         {
-          "expr": "chain_account_reads{quantile=\"$quantile\"}",
+          "expr": "chain_account_reads{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "account read (q=$quantile)",
           "refId": "D"
         },
         {
-          "expr": "chain_account_updates{quantile=\"$quantile\"}",
+          "expr": "chain_account_updates{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "account update (q=$quantile)",
           "refId": "E"
         },
         {
-          "expr": "chain_account_hashes{quantile=\"$quantile\"}",
+          "expr": "chain_account_hashes{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "account hashe (q=$quantile)",
           "refId": "F"
         },
         {
-          "expr": "chain_account_commits{quantile=\"$quantile\"}",
+          "expr": "chain_account_commits{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "account commit (q=$quantile)",
           "refId": "G"
         },
         {
-          "expr": "chain_storage_reads{quantile=\"$quantile\"}",
+          "expr": "chain_storage_reads{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "storage read (q=$quantile)",
           "refId": "H"
         },
         {
-          "expr": "chain_storage_updates{quantile=\"$quantile\"}",
+          "expr": "chain_storage_updates{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "storage update (q=$quantile)",
           "refId": "I"
         },
         {
-          "expr": "chain_storage_hashes{quantile=\"$quantile\"}",
+          "expr": "chain_storage_hashes{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "storage hashe (q=$quantile)",
           "refId": "J"
         },
         {
-          "expr": "chain_storage_commits{quantile=\"$quantile\"}",
+          "expr": "chain_storage_commits{quantile=\"$quantile\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "storage commit (q=$quantile)",
@@ -1490,21 +1490,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(txpool_valid[1m])",
+          "expr": "rate(txpool_valid{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "valid",
           "refId": "K"
         },
         {
-          "expr": "rate(txpool_invalid[1m])",
+          "expr": "rate(txpool_invalid{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "invalid",
           "refId": "A"
         },
         {
-          "expr": "rate(txpool_underpriced[1m])",
+          "expr": "rate(txpool_underpriced{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1513,7 +1513,7 @@
           "refId": "B"
         },
         {
-          "expr": "rate(txpool_pending_discard[1m])",
+          "expr": "rate(txpool_pending_discard{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1521,28 +1521,28 @@
           "refId": "C"
         },
         {
-          "expr": "rate(txpool_pending_replace[1m])",
+          "expr": "rate(txpool_pending_replace{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "executable replace",
           "refId": "D"
         },
         {
-          "expr": "rate(txpool_pending_ratelimit[1m])",
+          "expr": "rate(txpool_pending_ratelimit{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "executable ratelimit",
           "refId": "E"
         },
         {
-          "expr": "rate(txpool_pending_nofunds[1m])",
+          "expr": "rate(txpool_pending_nofunds{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "executable nofunds",
           "refId": "F"
         },
         {
-          "expr": "rate(txpool_queued_discard[1m])",
+          "expr": "rate(txpool_queued_discard{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1550,7 +1550,7 @@
           "refId": "G"
         },
         {
-          "expr": "rate(txpool_queued_replace[1m])",
+          "expr": "rate(txpool_queued_replace{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1558,7 +1558,7 @@
           "refId": "H"
         },
         {
-          "expr": "rate(txpool_queued_ratelimit[1m])",
+          "expr": "rate(txpool_queued_ratelimit{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1566,7 +1566,7 @@
           "refId": "I"
         },
         {
-          "expr": "rate(txpool_queued_nofunds[1m])",
+          "expr": "rate(txpool_queued_nofunds{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1671,28 +1671,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(eth_db_chaindata_disk_read[1m])",
+          "expr": "rate(eth_db_chaindata_disk_read{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "leveldb read",
           "refId": "B"
         },
         {
-          "expr": "rate(eth_db_chaindata_disk_write[1m])",
+          "expr": "rate(eth_db_chaindata_disk_write{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "leveldb write",
           "refId": "A"
         },
         {
-          "expr": "rate(eth_db_chaindata_ancient_read[1m])",
+          "expr": "rate(eth_db_chaindata_ancient_read{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "ancient read",
           "refId": "C"
         },
         {
-          "expr": "rate(eth_db_chaindata_ancient_write[1m])",
+          "expr": "rate(eth_db_chaindata_ancient_write{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "ancient write",
@@ -1782,28 +1782,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "eth_db_chaindata_disk_read",
+          "expr": "eth_db_chaindata_disk_read{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "leveldb read",
           "refId": "B"
         },
         {
-          "expr": "eth_db_chaindata_disk_write",
+          "expr": "eth_db_chaindata_disk_write{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "leveldb write",
           "refId": "A"
         },
         {
-          "expr": "eth_db_chaindata_ancient_read",
+          "expr": "eth_db_chaindata_ancient_read{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "ancient read",
           "refId": "C"
         },
         {
-          "expr": "eth_db_chaindata_ancient_write",
+          "expr": "eth_db_chaindata_ancient_write{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "ancient write",
@@ -1895,14 +1895,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "eth_db_chaindata_disk_size",
+          "expr": "eth_db_chaindata_disk_size{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "leveldb",
           "refId": "B"
         },
         {
-          "expr": "eth_db_chaindata_ancient_size",
+          "expr": "eth_db_chaindata_ancient_size{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "ancient",
@@ -2006,7 +2006,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(trie_memcache_clean_read[1m])",
+          "expr": "rate(trie_memcache_clean_read{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -2014,7 +2014,7 @@
           "refId": "C"
         },
         {
-          "expr": "rate(trie_memcache_clean_write[1m])",
+          "expr": "rate(trie_memcache_clean_write{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -2105,7 +2105,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(trie_memcache_gc_size[1m])",
+          "expr": "rate(trie_memcache_gc_size{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -2113,7 +2113,7 @@
           "refId": "C"
         },
         {
-          "expr": "rate(trie_memcache_flush_size[1m])",
+          "expr": "rate(trie_memcache_flush_size{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -2121,7 +2121,7 @@
           "refId": "B"
         },
         {
-          "expr": "rate(trie_memcache_commit_size[1m])",
+          "expr": "rate(trie_memcache_commit_size{instance=\"$instance\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "commit",
@@ -2273,6 +2273,28 @@
         "query": "0.5, 0.75, 0.95, 0.99, 0.999, 0.9999",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "10.0.0.78:7071",
+          "value": "10.0.0.78:7071"
+        },
+        "definition": "label_values(chain_head_header,instance)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(chain_head_header,instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },


### PR DESCRIPTION
Problem:

The user running multiple instances of Bor, but he/she cannot view the dashboards of different instances.

Solution:

Add an option to select target Bor instance.